### PR TITLE
Don't quote NISDOMAIN in /etc/sysconfig/network

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -53,7 +53,7 @@
   lineinfile:
     dest: /etc/sysconfig/network
     regexp: 'NISDOMAIN=.*'
-    line: 'NISDOMAIN=\"{{ nis_domain }}\"'
+    line: 'NISDOMAIN={{ nis_domain }}'
     backup: yes
     insertbefore: EOF
   notify:


### PR DESCRIPTION
Due to ansible 2.4 changes(?) these things turn up literally in the
file, e.g.

NISDOMAIN=\"foo\"

and hilarity ensues.