### PR TITLE
Added a better default for ypbind timeout

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -25,3 +25,4 @@ nis_manage_networkmanager: True
 nis_nm_enabled: "no"
 nis_nm_state: "stopped"
 nis_initialize: True
+nis_ypbind_timeout: 180

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -117,6 +117,10 @@
     line: 'NISTIMEOUT={{ nis_ypbind_timeout }}'
     backup: no
     insertbefore: EOF
+    create: yes
+    owner: root
+    mode: "0644"
+    group: root
   when: not nis_server 
 
 - name: enable and start ypbind

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -110,6 +110,15 @@
   notify:
     - restart ypserv
 
+- name: Set sane timeout for ypbind
+  lineinfile:  
+    dest: /etc/sysconfig/ypbind
+    regexp: 'NISTIMEOUT=.*'
+    line: 'NISTIMEOUT={{ nis_ypbind_timeout }}'
+    backup: no
+    insertbefore: EOF
+  when: not nis_server 
+
 - name: enable and start ypbind
   service:
     name: ypbind


### PR DESCRIPTION
Fixing a problem kale has: ypbind takes a long time coming up. Defaulting to 180 seconds of timeout for ypbind.
