### PR TITLE
Fix selinux

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -21,7 +21,7 @@
     setype: "passwd_file_t"
     state: file
 
-- name: set sensibe SELinux context on /etc/passwd
+- name: set sensibe SELinux context on /etc/shadow
   file:
     path: "/etc/shadow"
     mode: 0000

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -19,7 +19,7 @@
     seuser: "system_u"
     serole: "object_r"
     setype: "passwd_file_t"
-    state: present
+    state: file
 
 - name: set sensibe SELinux context on /etc/passwd
   file:
@@ -30,7 +30,7 @@
     seuser: "system_u"
     serole: "object_r"
     setype: "shadow_t"
-    state: present
+    state: file
 
 - name: install nis server packages
   package:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -10,16 +10,11 @@
     - restart rpcbind
     - restart ypbind
 
-chcon -h system_u:object_r:passwd_file_t:s0 /etc/passwd 
-chcon -h system_u:object_r:shadow_t:s0 /etc/shadow 
-
-
-
 - name: set sensibe SELinux context on /etc/passwd
   file:
     path: "/etc/passwd"
-    mode: 0644 
-    owner: "root"    
+    mode: 0644
+    owner: "root"
     group: "root"
     seuser: "system_u"
     serole: "object_r"
@@ -30,7 +25,7 @@ chcon -h system_u:object_r:shadow_t:s0 /etc/shadow
   file:
     path: "/etc/shadow"
     mode: 0000
-    owner: "root"    
+    owner: "root"
     group: "root"
     seuser: "system_u"
     serole: "object_r"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -32,6 +32,12 @@
     setype: "shadow_t"
     state: file
 
+- name: Fix SELinux context on /etc/password
+  command: "/usr/bin/chcon -h system_u:object_r:passwd_file_t:s0 /etc/passwd"
+
+- name: Fix SELinux context on /etc/shadow
+  command: "/usr/bin/chcon -h system_u:object_r:shadow_t:s0 /etc/shadow"
+
 - name: install nis server packages
   package:
     name: "{{ item }}"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -10,6 +10,33 @@
     - restart rpcbind
     - restart ypbind
 
+chcon -h system_u:object_r:passwd_file_t:s0 /etc/passwd 
+chcon -h system_u:object_r:shadow_t:s0 /etc/shadow 
+
+
+
+- name: set sensibe SELinux context on /etc/passwd
+  file:
+    path: "/etc/passwd"
+    mode: 0644 
+    owner: "root"    
+    group: "root"
+    seuser: "system_u"
+    serole: "object_r"
+    setype: "passwd_file_t"
+    state: present
+
+- name: set sensibe SELinux context on /etc/passwd
+  file:
+    path: "/etc/shadow"
+    mode: 0000
+    owner: "root"    
+    group: "root"
+    seuser: "system_u"
+    serole: "object_r"
+    setype: "shadow_t"
+    state: present
+
 - name: install nis server packages
   package:
     name: "{{ item }}"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -10,28 +10,6 @@
     - restart rpcbind
     - restart ypbind
 
-- name: set sensibe SELinux context on /etc/passwd
-  file:
-    path: "/etc/passwd"
-    mode: 0644
-    owner: "root"
-    group: "root"
-    seuser: "system_u"
-    serole: "object_r"
-    setype: "passwd_file_t"
-    state: file
-
-- name: set sensibe SELinux context on /etc/shadow
-  file:
-    path: "/etc/shadow"
-    mode: 0000
-    owner: "root"
-    group: "root"
-    seuser: "system_u"
-    serole: "object_r"
-    setype: "shadow_t"
-    state: file
-
 - name: Fix SELinux context on /etc/password
   command: "/usr/bin/chcon -h system_u:object_r:passwd_file_t:s0 /etc/passwd"
 


### PR DESCRIPTION
rpc.yppasswdd checks for security labels on /etc/passwd and /etc/shadow before it allows anyone to change passwords.
This is done in a patch added by redhat...

Ansible won't do security labels at all if selinux is disabled, so setting them via the file: module does not work.
The solution is a bit ugly.
Since the FGCI machines are installed and run without selinux enabled, and most changes done via ansible, all changed files in /etc have empty labels.. (shown as ? in ls -Z).